### PR TITLE
update project to work on mac again (10.9)

### DIFF
--- a/GNUstep.h
+++ b/GNUstep.h
@@ -1,0 +1,184 @@
+/* GNUstep.h - macros to make easier to port gnustep apps to macos-x
+   Copyright (C) 2001 Free Software Foundation, Inc.
+ 
+   Written by: Nicola Pero
+   Date: March, October 2001
+ 
+   This file is part of GNUstep.
+ 
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+ 
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+ 
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+ */
+
+#ifndef Performance_GNUstep_h
+#define Performance_GNUstep_h
+
+#ifndef	RETAIN
+/**
+ *	Basic retain operation ... calls [NSObject-retain]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	RETAIN(object)		[(id)(object) retain]
+#endif
+
+#ifndef	RELEASE
+/**
+ *	Basic release operation ... calls [NSObject-release]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	RELEASE(object)		[(id)(object) release]
+#endif
+
+#ifndef	AUTORELEASE
+/**
+ *	Basic autorelease operation ... calls [NSObject-autorelease]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	AUTORELEASE(object)	[(id)(object) autorelease]
+#endif
+
+#ifndef	TEST_RETAIN
+/**
+ *	Tested retain - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_RETAIN(object)	({\
+void *__object = (void*)(object);\
+(__object != 0) ? [(id)__object retain] : nil; })
+#endif
+
+#ifndef	TEST_RELEASE
+/**
+ *	Tested release - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_RELEASE(object)	({\
+void *__object = (void*)(object);\
+if (__object != 0) [(id)__object release]; })
+#endif
+
+#ifndef	TEST_AUTORELEASE
+/**
+ *	Tested autorelease - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_AUTORELEASE(object)	({\
+void *__object = (void*)(object);\
+(__object != 0) ? [(id)__object autorelease] : nil; })
+#endif
+
+#ifndef	ASSIGN
+/**
+ *	ASSIGN(object,value) assigns the value to the object with
+ *	appropriate retain and release operations.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGN(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) retain]; \
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	ASSIGNCOPY
+/**
+ *	ASSIGNCOPY(object,value) assigns a copy of the value to the object
+ *	with release of the original.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGNCOPY(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) copy];\
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	ASSIGNMUTABLECOPY
+/**
+ *	ASSIGNMUTABLECOPY(object,value) assigns a mutable copy of the value
+ *	to the object with release of the original.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGNMUTABLECOPY(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) mutableCopy];\
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	DESTROY
+/**
+ *	DESTROY() is a release operation which also sets the variable to be
+ *	a nil pointer for tidiness - we can't accidentally use a DESTROYED
+ *	object later.  It also makes sure to set the variable to nil before
+ *	releasing the object - to avoid side-effects of the release trying
+ *	to reference the object being released through the variable.
+ */
+#define	DESTROY(object) 	({ \
+void *__o = (void*)object; \
+object = nil; \
+[(id)__o release]; \
+})
+#endif
+
+#ifndef DEALLOC
+/**
+ *	DEALLOC calls the superclass implementation of dealloc, unless
+ *	ARC is in use (in which case it does nothing).
+ */
+#define DEALLOC         [super dealloc];
+#endif
+
+#ifndef ENTER_POOL
+/**
+ *	ENTER_POOL creates an autorelease pool and places subsequent code
+ *	in a block.<br />
+ *	The block must be terminated with a corresponding LEAVE_POOL.<br />
+ *	You should not break, continue, or return from such a block of code
+ *	(to do so could leak an autorelease pool and give objects a longer
+ *	lifetime than they ought to have.  If you wish to leave the block of
+ *	code early, you should ensure that doing so causes the autorelease
+ *	pool outside the block to be released promptly (since that will
+ *	implicitly release the pool created at the start of the block too).
+ */
+#define ENTER_POOL      {NSAutoreleasePool *_lARP=[NSAutoreleasePool new];
+#endif
+
+#ifndef LEAVE_POOL
+/**
+ *	LEAVE_POOL terminates a block of code started with ENTER_POOL.
+ */
+#define LEAVE_POOL      [_lARP drain];}
+#endif
+
+
+#ifndef __has_feature      // Optional.
+#define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+
+#ifndef NS_CONSUMED
+#if __has_feature(attribute_ns_consumed)
+#define NS_CONSUMED __attribute__((ns_consumed))
+#else
+#define NS_CONSUMED
+#endif
+#endif
+
+
+
+#endif

--- a/GSFIFO.h
+++ b/GSFIFO.h
@@ -25,6 +25,11 @@
 #import <Foundation/NSObject.h>
 #import <Foundation/NSDate.h>
 
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
+
+
 @class NSArray;
 @class NSCondition;
 @class NSNumber;

--- a/GSIOThreadPool.h
+++ b/GSIOThreadPool.h
@@ -25,9 +25,6 @@
 #import <Foundation/NSObject.h>
 #import <Foundation/NSThread.h>
 
-#if !defined (GNUSTEP) && (MAC_OS_X_VERSION_MAX_ALLOWED<=MAC_OS_X_VERSION_10_4)
-typedef unsigned int NSUInteger;
-#endif
 
 @class	NSMutableArray;
 @class	NSTimer;

--- a/GSIOThreadPool.m
+++ b/GSIOThreadPool.m
@@ -29,7 +29,12 @@
 #import <Foundation/NSTimer.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSUserDefaults.h>
+#import <Foundation/NSAutoreleasePool.h>
 #import	"GSIOThreadPool.h"
+
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
 
 /* Protect changes to a thread's counter
  */

--- a/GSLinkedList.h
+++ b/GSLinkedList.h
@@ -24,10 +24,6 @@
    */
 #import <Foundation/NSObject.h>
 
-#if !defined (GNUSTEP) &&  (MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_4)
-typedef unsigned int NSUInteger;
-#endif
-
 @class GSLinkedList;
 
 /** GSListLink provides simple doubly linked list functionality to

--- a/GSLinkedList.m
+++ b/GSLinkedList.m
@@ -25,13 +25,18 @@
 #import <Foundation/NSException.h>
 #import "GSLinkedList.h"
 
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
+
+
 @implementation	GSListLink
 
 - (void) dealloc
 {
   NSAssert(nil == owner, NSInternalInconsistencyException);
   [item release];
-  [super dealloc];
+  DEALLOC;
 }
 
 - (id) initCircular
@@ -76,7 +81,7 @@
   id	o = item;
 
   item = [anItem retain];
-  [o release];
+  RELEASE(o);
 }
 
 @end
@@ -108,7 +113,7 @@
 	    NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
 	}
       GSLinkedListInsertAfter(link, self, tail);
-      [link retain];
+      RETAIN(link);
     }
 }
 
@@ -120,7 +125,7 @@
 - (void) dealloc
 {
   [self empty];
-  [super dealloc];
+  DEALLOC;
 }
 
 - (void) empty
@@ -132,7 +137,7 @@
       head = link->next;
       link->owner = nil;
       link->next = link->previous = nil;
-      [link release];
+      RELEASE(link);
     }
   tail = nil;
   count = 0;
@@ -205,7 +210,7 @@
 	    NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
 	}
       GSLinkedListInsertAfter(link, self, at);
-      [link retain];
+      RETAIN(link);
     }
 }
 
@@ -245,7 +250,7 @@
 	    NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
 	}
       GSLinkedListInsertBefore(link, self, at);
-      [link retain];
+      RETAIN(link);
     }
 }
 
@@ -264,7 +269,7 @@
 	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
   GSLinkedListRemove(link, self);
-  [link release];
+  RETAIN(link);
 }
 
 - (GSListLink*) tail

--- a/GSThreadPool.m
+++ b/GSThreadPool.m
@@ -9,6 +9,11 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSException.h>
 
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
+
+
 @class	GSThreadPool;
 
 @interface	GSOperation : GSListLink

--- a/GSThroughput.m
+++ b/GSThroughput.m
@@ -43,6 +43,11 @@
 #import	"GSThroughput.h"
 #import	"GSTicker.h"
 
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
+
+
 NSString * const GSThroughputNotification = @"GSThroughputNotification";
 NSString * const GSThroughputCountKey = @"Count";
 NSString * const GSThroughputMaximumKey = @"Maximum";

--- a/NSObject+GSExtensions.h
+++ b/NSObject+GSExtensions.h
@@ -26,8 +26,8 @@
 
 #import <Foundation/NSObject.h>
 
-#if !defined(GNUSTEP)
-#define RETAIN(x) ([x retain])
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
 #endif
 
 @class NSHashTable;

--- a/Performance.xcodeproj/project.pbxproj
+++ b/Performance.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 42;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -28,6 +28,7 @@
 		85B7DBDD1C034FBA00AF3090 /* NSObject+GSExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B7DBDB1C034FBA00AF3090 /* NSObject+GSExtensions.m */; };
 		85B7DC031C036A0900AF3090 /* GSFIFO.h in Headers */ = {isa = PBXBuildFile; fileRef = 85B7DC011C036A0900AF3090 /* GSFIFO.h */; };
 		85B7DC041C036A0900AF3090 /* GSFIFO.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B7DC021C036A0900AF3090 /* GSFIFO.m */; };
+		85DA4C012C41D1A900FC0E77 /* GNUstep.h in Headers */ = {isa = PBXBuildFile; fileRef = 85DA4C002C41D1A900FC0E77 /* GNUstep.h */; };
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,7 @@
 		85B7DBDB1C034FBA00AF3090 /* NSObject+GSExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+GSExtensions.m"; sourceTree = "<group>"; };
 		85B7DC011C036A0900AF3090 /* GSFIFO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSFIFO.h; sourceTree = "<group>"; };
 		85B7DC021C036A0900AF3090 /* GSFIFO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GSFIFO.m; sourceTree = "<group>"; };
+		85DA4C002C41D1A900FC0E77 /* GNUstep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GNUstep.h; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -139,6 +141,7 @@
 				85872EC01284CFC700B4601E /* Performance.h */,
 				85B7DBDA1C034FBA00AF3090 /* NSObject+GSExtensions.h */,
 				85B7DBDB1C034FBA00AF3090 /* NSObject+GSExtensions.m */,
+				85DA4C002C41D1A900FC0E77 /* GNUstep.h */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -180,6 +183,7 @@
 				85872EC51284CFC700B4601E /* GSIOThreadPool.h in Headers */,
 				85872EC71284CFC700B4601E /* GSLinkedList.h in Headers */,
 				85872EC91284CFC700B4601E /* GSSkipMutableArray.h in Headers */,
+				85DA4C012C41D1A900FC0E77 /* GNUstep.h in Headers */,
 				85872ECB1284CFC700B4601E /* GSThreadPool.h in Headers */,
 				85872ECD1284CFC700B4601E /* GSThroughput.h in Headers */,
 				85872ECF1284CFC700B4601E /* GSTicker.h in Headers */,
@@ -217,10 +221,12 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = gnustep.org;
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "Performance" */;
-			compatibilityVersion = "Xcode 2.4";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				English,
@@ -284,7 +290,7 @@
 		1DEB91AE08733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -304,6 +310,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				PRODUCT_NAME = Performance;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 				ZERO_LINK = YES;
 			};
@@ -312,8 +319,7 @@
 		1DEB91AF08733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
+				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
@@ -329,6 +335,7 @@
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
 				PRODUCT_NAME = Performance;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;
@@ -336,13 +343,13 @@
 		1DEB91B208733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				PRODUCT_NAME = Performance;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "$(PROJECT_DIR)/build";
 			};
 			name = Debug;
@@ -350,15 +357,13 @@
 		1DEB91B308733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
 				GCC_MODEL_TUNING = "";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				PRODUCT_NAME = Performance;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "$(PROJECT_DIR)/build";
 			};
 			name = Release;


### PR DESCRIPTION
Make work on Mac again - 10.9 since it has TLS 1.3
Remove hacks for 10.4 and earlier

Cleanup usage of GNUstep macros, specify GNUstep.h as compatibility, put macros inside and try to use GNUstep memory macros missed in some spots.